### PR TITLE
Change Item image cropping

### DIFF
--- a/resources/css/elements/item-image-display.css
+++ b/resources/css/elements/item-image-display.css
@@ -5,6 +5,8 @@
     width: 250px;
     height: 250px;
     transition: all 0.1s ease-in-out;
+    background-size: cover;
+    background-position: center;
 }
 
 #main-image:hover


### PR DESCRIPTION
Automatically crop images to cover the whole item element starting from the center, cut off the rest